### PR TITLE
use golang 1.10.x when to deploy via travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ deploy:
     - pkg/*
   on:
     tags: true
-    go: 1.10.3
+    go: 1.10.x


### PR DESCRIPTION
modify deploy golang dependency to upload release files via travis ci.