### PR TITLE
Import time/tzdata to include tzinfo in an application.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ jobs:
     strategy:
       matrix:
         go:
-          - 1.14
           - 1.15
     name: Build
     runs-on: ubuntu-latest

--- a/cmd/sqsjkr/main.go
+++ b/cmd/sqsjkr/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"runtime"
+	_ "time/tzdata"
 
 	"github.com/kayac/sqsjkr"
 	"github.com/kayac/sqsjkr/lock"


### PR DESCRIPTION
Drop support Go 1.14.